### PR TITLE
fix: vite.config.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import GitRevision from 'vite-plugin-git-revision';
 export default {
   plugins: [
     Vue(), 
-    GitRevision()
+    GitRevision({})
   ],
 };
 ```


### PR DESCRIPTION
Looking at the type definition it expects one argument.